### PR TITLE
feat: GitHub Copilot を自動レビュワーとして追加

### DIFF
--- a/.github/workflows/chores.yml
+++ b/.github/workflows/chores.yml
@@ -18,3 +18,17 @@ jobs:
           GH_REPO: ${{ github.repository }}
         if: ${{ toJSON(github.event.pull_request.assignees) == '[]' }}
 
+  add-copilot-reviewer:
+    name: Add Copilot as Reviewer
+    if: github.actor != 'dependabot[bot]' && (github.event.action == 'opened' || github.event.action == 'ready_for_review')
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+
+    steps:
+      - run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --add-reviewer copilot
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+


### PR DESCRIPTION
## 概要
PR が開かれた際に GitHub Copilot を自動的にレビュワーとして追加する機能を chores workflow に追加しました。

## 変更内容
- `.github/workflows/chores.yml` に `add-copilot-reviewer` ジョブを追加
- PR が開かれた時、またはレビュー準備が整った時に自動的に GitHub Copilot をレビュワーとして追加

## 確認事項
- [x] 必要に応じてテストを追加・更新した
- [x] 関連するドキュメントを更新した（必要な場合）

## その他
このジョブは `dependabot[bot]` による PR では実行されません。

--

GitHub Copilot コードレビューへの指示: この PR のレビューコメントは日本語で行うこと

🤖 Generated with [Claude Code](https://claude.ai/code)