### PR TITLE
feat: add Claude Code GitHub Action workflow

### DIFF
--- a/.github/workflows/chores.yml
+++ b/.github/workflows/chores.yml
@@ -3,6 +3,7 @@ on:
   workflow_call:
 
 jobs:
+  # PR 作成者を assignee に追加する
   assign:
     name: Auto Assign
     if: github.actor != 'dependabot[bot]' && (github.event.action == 'opened' || github.event.action == 'ready_for_review')
@@ -18,6 +19,9 @@ jobs:
           GH_REPO: ${{ github.repository }}
         if: ${{ toJSON(github.event.pull_request.assignees) == '[]' }}
 
+
+  # copilot を reviewer に追加する
+  # (2025/07 現在, 無料プランでは自動追加ができない)
   add-copilot-reviewer:
     name: Add Copilot as Reviewer
     if: github.actor != 'dependabot[bot]' && (github.event.action == 'opened' || github.event.action == 'ready_for_review')

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,38 @@
+name: claude
+on:
+  workflow_call:
+
+jobs:
+  claude-code-action-for-grandcolline:
+    if: |
+      (github.event_name == 'issue_comment' && github.event.comment.user.login == 'grandcolline' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && github.event.comment.user.login == 'grandcolline' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && github.event.review.user.login == 'grandcolline' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.issue.user.login == 'grandcolline' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FOR_GRANDCOLLINE }}
+          timeout_minutes: "60"
+          # Optional: Restrict network access to specific domains only
+          # experimental_allowed_domains: |
+          #   .anthropic.com
+          #   .github.com
+          #   api.github.com
+          #   .githubusercontent.com
+          #   bun.sh
+          #   registry.npmjs.org
+          #   .blob.core.windows.net
+


### PR DESCRIPTION
## Summary
- grandcolline ユーザー専用のClaude Code GitHub Actionワークフローを追加
- issue、PR、レビューコメントで @claude をメンションすることで起動
- chores.yml にコメントを追加して可読性を向上

## Test plan
- [ ] GitHub Actionsのワークフロー構文が正しいことを確認
- [ ] grandcollineユーザーが @claude をメンションした際にワークフローが起動することを確認
- [ ] 他のユーザーが @claude をメンションしてもワークフローが起動しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)