### PR TITLE
feat: enable workflows to trigger on PR events while maintaining reusability

### DIFF
--- a/.github/workflows/chores.yml
+++ b/.github/workflows/chores.yml
@@ -1,6 +1,8 @@
 name: chores
 on:
   workflow_call:
+  pull_request:
+    types: [opened, ready_for_review]
 
 jobs:
   # PR 作成者を assignee に追加する

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,11 @@
 name: claude
 on:
   workflow_call:
+  pull_request:
+  pull_request_review:
+  pull_request_review_comment:
+  issue_comment:
+  issues:
 
 jobs:
   claude-code-action-for-grandcolline:


### PR DESCRIPTION
## 概要
reusable workflowsとして設定されているworkflowファイルに、このレポジトリのPRでも発火するようにイベントトリガーを追加しました。

## 変更内容
- `chores.yml` に `pull_request` イベント（`opened`, `ready_for_review` タイプ）を追加
- `claude.yml` に `pull_request`, `pull_request_review`, `pull_request_review_comment`, `issue_comment`, `issues` イベントを追加
- 既存の `workflow_call` は維持し、reusable workflowとしても引き続き利用可能

## 確認事項
- [x] 必要に応じてテストを追加・更新した
- [x] 関連するドキュメントを更新した（必要な場合）

## その他
この変更により、両方のワークフローは以下の両方の機能を提供します：
1. 他のレポジトリからのreusable workflowとしての利用
2. このレポジトリ内のPRで直接発火

--

GitHub Copilot コードレビューへの指示: この PR のレビューコメントは日本語で行うこと

🤖 Generated with [Claude Code](https://claude.ai/code)