### PR TITLE
fix: Claude Actions に cat と base64 コマンドの実行権限を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,6 +33,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FOR_GRANDCOLLINE }}
           timeout_minutes: "60"
           allowed_tools: |
+            Bash(cat)
+            Bash(base64)
             Bash(bun:*)
             Bash(gh:*)
           # Optional: Restrict network access to specific domains only


### PR DESCRIPTION
## 概要
Claude Actions ワークフローで `gh pr create` や `gh api` コマンドを実行する際に必要な `cat` と `base64` コマンドの実行権限を追加しました。

## 関連 Issue
<\!-- この PR に関連する Issue はありません -->

## 変更内容
- Claude Actions の `allowed_tools` に `Bash(cat)` を追加（HEREDOC での PR 作成に必要）
- Claude Actions の `allowed_tools` に `Bash(base64)` を追加（GitHub API レスポンスのデコードに必要）

## 確認事項
- [x] 必要に応じてテストを追加・更新した
- [x] 関連するドキュメントを更新した（必要な場合）

## その他
これらの権限追加により、Claude が以下のようなコマンドを実行できるようになります：
- `gh pr create` で HEREDOC を使用した PR 作成
- `gh api` の結果を `base64 -d` でデコード

--

GitHub Copilot コードレビューへの指示: この PR のレビューコメントは日本語で行うこと

🤖 Generated with [Claude Code](https://claude.ai/code)