### PR TITLE
fix: expose matrix environment results

### DIFF
--- a/.github/workflows/deploy_workers_with_bun.yml
+++ b/.github/workflows/deploy_workers_with_bun.yml
@@ -73,7 +73,7 @@ jobs:
       matrix:
         environment: ${{ fromJSON(inputs.envs) }}
     outputs:
-      status: ${{ steps.output.outputs.deploy-status }}
+      ${{ matrix.environment }}: ${{ steps.output.outputs.deploy-status }}
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
- ensure deploy job outputs are keyed by environment so all matrix results are available

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc4ff13048321af9faba10ffb5d1d