### PR TITLE
fix: 単一環境でのデプロイメント結果処理を修正

### DIFF
--- a/.github/workflows/deploy_workers_with_bun.yml
+++ b/.github/workflows/deploy_workers_with_bun.yml
@@ -141,7 +141,18 @@ jobs:
             const files = fs.readdirSync(dir);
 
             files.forEach(file => {
-              const filePath = path.join(dir, file, 'result.json');
+              let filePath;
+              const fullPath = path.join(dir, file);
+              
+              // ファイルかディレクトリかを判定
+              if (fs.statSync(fullPath).isDirectory()) {
+                // 複数環境の場合：results/deploy-result-env/result.json
+                filePath = path.join(fullPath, 'result.json');
+              } else {
+                // 単一環境の場合：results/result.json
+                filePath = fullPath;
+              }
+              
               const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
               const statusEmoji = data.status === 'success' ? '✅' : '❌';
               message += `| ${data.environment} | ${statusEmoji} ${data.status} | ${data.url} |\n`;


### PR DESCRIPTION
## 概要
deploy_workers_with_bun.yml の Result ジョブで単一環境でのデプロイ時にエラーが発生する問題を修正しました。従来は複数環境を前提とした処理のため、単一環境の場合にファイルパスが不正になっていました。

## 関連 Issue
<!-- この PR に関連する Issue があれば記載してください -->

## 変更内容
- `fs.statSync()` を使用してファイル/ディレクトリを判定するロジックを追加
- 単一環境の場合：`results/result.json` として直接ファイルを参照
- 複数環境の場合：`results/deploy-result-env/result.json` としてディレクトリ内のファイルを参照
- `.github/workflows/deploy_workers_with_bun.yml` の144-159行目を修正

## 確認事項
- [x] 必要に応じてテストを追加・更新した
- [x] 関連するドキュメントを更新した（必要な場合）

## その他
- GitHub Copilot コードレビューへの指示: この PR のレビューコメントは日本語で行うこと
- 単一環境と複数環境の両方で動作確認が必要です

🤖 Generated with [Claude Code](https://claude.ai/code)