### PR TITLE
feat: Bunコマンドによる自動更新を行うReusable Workflowを追加

### DIFF
--- a/.github/workflows/auto_update_with_bun.yml
+++ b/.github/workflows/auto_update_with_bun.yml
@@ -13,6 +13,8 @@ jobs:
   auto-update:
     name: Auto Update
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/auto_update_with_bun.yml
+++ b/.github/workflows/auto_update_with_bun.yml
@@ -1,0 +1,80 @@
+name: Auto Update with Bun
+on:
+  workflow_call:
+    inputs:
+      commands:
+        type: string
+        required: false
+        default: '["fmt", "typegen", "db:generate"]'
+        description: |
+          JSON 形式の実行するコマンドの配列 (e.g. '["fmt","typegen"]')
+
+jobs:
+  auto-update:
+    name: Auto Update
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run Commands
+        id: run-commands
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const commands = JSON.parse('${{ inputs.commands }}');
+
+            console.log('📦 bun コマンドを実行中...');
+
+            // 各コマンドを実行
+            for (const cmd of commands) {
+              console.log(`\n🔧 実行中: bun run ${cmd}`);
+              try {
+                const output = execSync(`bun run ${cmd}`, {
+                  encoding: 'utf-8',
+                  stdio: 'pipe'
+                });
+                console.log(output);
+              } catch (error) {
+                console.error(`⚠️ コマンドが失敗しました: ${cmd}`);
+                console.error(error.message);
+                // エラーが発生しても他のコマンドは継続実行
+              }
+            }
+
+            // 変更を確認
+            const gitStatus = execSync('git status --porcelain', { encoding: 'utf-8' });
+            const hasChanges = gitStatus.trim().length > 0;
+
+            if (hasChanges) {
+              console.log('\n✅ 変更が検出されました');
+              core.setOutput('changes', 'true');
+            } else {
+              console.log('\n📭 変更はありません');
+              core.setOutput('changes', 'false');
+            }
+
+            return hasChanges;
+
+      - name: Commit and Push Changes
+        if: steps.run-commands.outputs.changes == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          # すべての変更をステージング
+          git add -A
+
+          # コミットメッセージを作成
+          git commit -m "chore: auto-update from bun commands
+
+          Executed commands: ${{ inputs.commands }}
+
+          Co-authored-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+
+          # 現在のブランチにプッシュ
+          git push origin HEAD

--- a/.github/workflows/auto_update_with_bun.yml
+++ b/.github/workflows/auto_update_with_bun.yml
@@ -72,11 +72,13 @@ jobs:
           git add -A
 
           # コミットメッセージを作成
-          git commit -m "chore: auto-update from bun commands
+          git commit -F - <<'EOF'
+chore: bunコマンドによる自動更新
 
-          Executed commands: ${{ inputs.commands }}
+Commands: ${{ inputs.commands }}
 
-          Co-authored-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+Co-authored-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+EOF
 
           # 現在のブランチにプッシュ
           git push origin HEAD


### PR DESCRIPTION
## 概要
組織内の各リポジトリで使用できる、Bunコマンドの実行結果を自動的にコミット・プッシュするReusable Workflowを追加しました。

## 関連 Issue
<!-- なし -->

なし

## 変更内容
- 新しいReusable Workflow `auto_update_with_bun.yml` を追加
- Bunコマンドを実行し、変更があった場合に自動コミット・プッシュする機能を実装
- actions/github-scriptを使用した見やすく保守しやすい実装

## 主な機能
- 📦 複数のBunコマンドをJSON配列で指定可能（デフォルト: fmt, typegen, db:generate）
- 🔧 エラーが発生しても他のコマンドは継続実行
- ✅ 変更検出とGitHub Actions botによる自動コミット
- 📝 すべてのコメントとログを日本語化

## 使用方法
```yaml
jobs:
  auto-update:
    uses: nw-union/.github/.github/workflows/auto_update_with_bun.yml@main
    with:
      commands: '["fmt", "lint", "test"]'
```

## 確認事項
- [x] 必要に応じてテストを追加・更新した
- [x] 関連するドキュメントを更新した（必要な場合）

## その他
- GitHub Copilot コードレビューへの指示: この PR のレビューコメントは日本語で行うこと
- このワークフローは組織内の他のリポジトリから呼び出し可能なReusable Workflowです

🤖 Generated with [Claude Code](https://claude.ai/code)