### PR TITLE
fix: specify ref when pushing

### DIFF
--- a/.github/workflows/auto_update_with_bun.yml
+++ b/.github/workflows/auto_update_with_bun.yml
@@ -78,4 +78,4 @@ jobs:
             -m "Co-authored-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
 
           # 現在のブランチにプッシュ
-          git push origin HEAD
+          git push origin HEAD:${{ github.ref }}


### PR DESCRIPTION
## Summary
- specify ref when pushing in auto_update_with_bun workflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c68be537888321b66d4d4e667c306b