### PR TITLE
fix(workflow): push to branch for PR

### DIFF
--- a/.github/workflows/auto_update_with_bun.yml
+++ b/.github/workflows/auto_update_with_bun.yml
@@ -77,5 +77,10 @@ jobs:
             -m "" \
             -m "Co-authored-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
 
-          # 現在のブランチにプッシュ
-          git push origin HEAD
+          # 現在のブランチにプッシュ（フル参照を使用）
+          REF_TO_PUSH="${GITHUB_REF}"
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            REF_TO_PUSH="refs/heads/${GITHUB_HEAD_REF}"
+          fi
+
+          git push origin HEAD:$REF_TO_PUSH

--- a/.github/workflows/auto_update_with_bun.yml
+++ b/.github/workflows/auto_update_with_bun.yml
@@ -79,7 +79,8 @@ jobs:
 
           # 現在のブランチにプッシュ（フル参照を使用）
           REF_TO_PUSH="${GITHUB_REF}"
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+          if [ -n "${GITHUB_HEAD_REF}" ]; then
+            # pull_request イベントではマージリファレンスではなくヘッドブランチにプッシュ
             REF_TO_PUSH="refs/heads/${GITHUB_HEAD_REF}"
           fi
 


### PR DESCRIPTION
## Summary
- adjust auto_update_with_bun workflow to push to correct branch when triggered by pull_request
- clarify comment about using full ref when pushing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c68be537888321b66d4d4e667c306b