### PR TITLE
chore: GitHub Actions のバージョンをSHAハッシュで固定する

### DIFF
--- a/.github/workflows/auto_update_with_bun.yml
+++ b/.github/workflows/auto_update_with_bun.yml
@@ -31,24 +31,24 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: github-app-token
         with:
           app-id: ${{ secrets.GH_APPS_APP_ID }}
           private-key: ${{ secrets.GH_APPS_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }} # For creating a token for all repositories in the current owner's installation
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ steps.github-app-token.outputs.token }}
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
       - name: Run Commands And Push
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { execSync } = require('child_process');

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 
       - name: Run Claude PR Action
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FOR_GRANDCOLLINE }}
           timeout_minutes: "60"

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -11,8 +11,8 @@ jobs:
     name: Biome
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: mongolyy/reviewdog-action-biome@v2.11.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: mongolyy/reviewdog-action-biome@58f27dce74f1f648943d3a88de554385727ce11b # v2.11.1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
@@ -25,8 +25,8 @@ jobs:
     name: Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: reviewdog/action-typos@v1.19.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: reviewdog/action-typos@d5eb1bbcd1b3bfde596f6eeb470322727862fe98 # v1.19.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
@@ -39,8 +39,8 @@ jobs:
     name: Gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: reviewdog/action-gitleaks@v1.8.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: reviewdog/action-gitleaks@2b7b5685e3e3eecddab5d30cfa04f18123031421 # v1.8.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review

--- a/.github/workflows/deploy_workers_with_bun.yml
+++ b/.github/workflows/deploy_workers_with_bun.yml
@@ -49,8 +49,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -59,7 +59,7 @@ jobs:
         run: bun run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-artifacts
           include-hidden-files: true
@@ -73,21 +73,21 @@ jobs:
       matrix:
         environment: ${{ fromJSON(inputs.envs) }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies # TODO: 無くしたい
         run: bun install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-artifacts
           path: ${{ inputs.artifacts-download-path }}
 
       - name: Deploy
         id: deploy
-        uses: cloudflare/wrangler-action@v4.0.0
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Save deployment result
         if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload deployment result
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deploy-result-${{ matrix.environment }}
           path: result.json
@@ -120,14 +120,14 @@ jobs:
     if: always()
     steps:
       - name: Download deployment results
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: deploy-result-*
           path: results
 
       - name: Generate deployment message
         id: message
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -162,14 +162,14 @@ jobs:
             core.exportVariable('DEPLOY_MESSAGE', message);
 
       - name: Write Summary
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const message = process.env.DEPLOY_MESSAGE || '';
             await core.summary.addRaw(message).write();
 
       - name: Comment on PR
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         if: github.event_name == 'pull_request' # PR の場合はコメントを残す
         with:
           script: |


### PR DESCRIPTION
## 概要
GitHub Actions のバージョン指定をタグからコミットSHAハッシュに変更する。
タグは後から書き換えが可能なため、SHA固定にすることでサプライチェーン攻撃のリスクを低減する。
SHA の横にバージョンタグをコメントで記載し、可読性を維持する。

## 変更内容
- `actions/checkout`: `v6` → `v6.0.3` (SHA固定)
- `oven-sh/setup-bun`: `v2` → `v2.2.0` (SHA固定)
- `actions/upload-artifact`: `v7.0.1` → SHA固定
- `actions/download-artifact`: `v8.0.1` → SHA固定
- `cloudflare/wrangler-action`: `v4.0.0` → SHA固定
- `actions/github-script`: `v9` → `v9.0.0` (SHA固定)
- `mongolyy/reviewdog-action-biome`: `v2.11.1` → SHA固定
- `reviewdog/action-typos`: `v1.19.0` → SHA固定
- `reviewdog/action-gitleaks`: `v1.8.0` → SHA固定
- `actions/create-github-app-token`: `v3` → `v3.2.0` (SHA固定)
- `anthropics/claude-code-action`: `beta` → SHA固定

## 確認事項
- [x] 必要に応じてテストを追加・更新した
- [x] 関連するドキュメントを更新した（必要な場合）

## その他
- GitHub Copilot コードレビューへの指示: この PR のレビューコメントは日本語で行うこと